### PR TITLE
fix: DOT parameters and yarn build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build:snap": "yarn workspace polkadot-snap build",
+    "build:snap": "yarn workspace @chainsafe/polkadot-snap build",
     "build:adapter": "yarn workspace @chainsafe/metamask-polkadot-adapter build",
     "start:snap": "yarn workspace @chainsafe/polkadot-snap serve",
     "start:example": "yarn workspace example start",

--- a/packages/example/src/services/format.ts
+++ b/packages/example/src/services/format.ts
@@ -4,6 +4,7 @@ export function shortAddress(address: string): string {
 
 export function getCurrency(network: string): string {
   switch (network) {
+    case "polkadot": return "DOT";
     case "kusama": return "KSM";
     case "westend": return "WND";
   }

--- a/packages/example/src/services/polkascan.ts
+++ b/packages/example/src/services/polkascan.ts
@@ -1,5 +1,7 @@
 export function getPolkascanTxUrl(txHash: string, network: string): string {
   switch (network) {
+    case "polkadot":
+      return `https://polkadot.subscan.io/extrinsic/${txHash}`;
     case "kusama":
       return `https://polkascan.io/kusama/transaction/${txHash}`;
     case "westend":

--- a/packages/snap/src/configuration/predefined.ts
+++ b/packages/snap/src/configuration/predefined.ts
@@ -25,7 +25,7 @@ export const polkadotConfiguration: SnapConfig = {
   addressPrefix: 0,
   networkName: "polkadot",
   unit: {
-    decimals: 12,
+    decimals: 10,
     image: "https://polkadot.js.org/apps/static/polkadot-circle.1eea41b2..svg",
     symbol: "DOT",
   },


### PR DESCRIPTION
- Fixes yarn build:snap
- add DOT as a currency
- add explorer for polkadot
- DOT has [10 decimals](https://wiki.polkadot.network/docs/build-protocol-info#tokens)