### PR TITLE
fix: transfer method polkadot js update

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          cache: yarn
           node-version: '16.x'
       - run: corepack enable
       - run: yarn install --immutable
@@ -49,7 +48,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          cache: yarn
           node-version: '16.x'
       - run: corepack enable
       - name: Install

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/chainsafe/metamask-snap-polkadot.git"
   },
   "source": {
-    "shasum": "xo6heOlvwxUwc0v1/sEgaVJM7eMemuhUS+U/5AxnjFc=",
+    "shasum": "lF1WLH7ZVBdvrdv92FHQwCfqmlkMSgPTu1KdpboLwv4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/chainsafe/metamask-snap-polkadot.git"
   },
   "source": {
-    "shasum": "GwKusydp1vpDXY7B98s0zjVphX1d16ZnkGG3xfPqXHM=",
+    "shasum": "xo6heOlvwxUwc0v1/sEgaVJM7eMemuhUS+U/5AxnjFc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/rpc/generateTransactionPayload.ts
+++ b/packages/snap/src/rpc/generateTransactionPayload.ts
@@ -20,8 +20,12 @@ export async function generateTransactionPayload(
     }),
     nonce
   };
+
   // define transaction method
-  const transaction: SubmittableExtrinsic<'promise'> = api.tx.balances.transfer(to, amount);
+  const transaction: SubmittableExtrinsic<'promise'> = api.tx.balances.transferAllowDeath(
+    to,
+    amount
+  );
 
   // create SignerPayload
   const signerPayload = api.createType('SignerPayload', {

--- a/packages/snap/src/rpc/generateTransactionPayload.ts
+++ b/packages/snap/src/rpc/generateTransactionPayload.ts
@@ -22,7 +22,7 @@ export async function generateTransactionPayload(
   };
 
   // define transaction method
-  const transaction: SubmittableExtrinsic<'promise'> = api.tx.balances.transferAllowDeath(
+  const transaction: SubmittableExtrinsic<'promise'> = api.tx.balances.transferKeepAlive(
     to,
     amount
   );

--- a/packages/snap/src/rpc/send.ts
+++ b/packages/snap/src/rpc/send.ts
@@ -16,7 +16,7 @@ export async function send(
 
   const amount = extrinsic.args[1].toJSON();
   const paymentInfo = await api.tx.balances
-    .transferAllowDeath(destination, String(amount))
+    .transferKeepAlive(destination, String(amount))
     .paymentInfo(sender);
 
   const txHash = await api.rpc.author.submitExtrinsic(extrinsic);

--- a/packages/snap/src/rpc/send.ts
+++ b/packages/snap/src/rpc/send.ts
@@ -16,7 +16,7 @@ export async function send(
 
   const amount = extrinsic.args[1].toJSON();
   const paymentInfo = await api.tx.balances
-    .transfer(destination, String(amount))
+    .transferAllowDeath(destination, String(amount))
     .paymentInfo(sender);
 
   const txHash = await api.rpc.author.submitExtrinsic(extrinsic);


### PR DESCRIPTION
Transfer method got deprecated, updated with transferAllowDeath
https://github.com/paritytech/substrate/pull/12951

Fix #206